### PR TITLE
replace youtube iframe with video tag

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-public/video/** filter=lfs diff=lfs merge=lfs -text
+public/videos/** filter=lfs diff=lfs merge=lfs -text
 * text=auto eol=lf

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -17,7 +17,7 @@ test('header bar contains title and menu button', async ({ page }) => {
 test('banner contains title, subtitle, call to action and social media icons', async ({ page }) => {
   await page.goto('/')
 
-  await expect(page.getByRole('img', {name: 'Club Live Logo'})).toBeVisible()
+  await expect(page.getByRole('img', { name: 'Club Live Logo' })).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Live-Band aus Karlsruhe' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'Jetzt reinhören' })).toBeVisible()
 
@@ -49,7 +49,10 @@ test('start section contains heading, video and info paragraph', async ({ page }
   await page.goto('/#start')
 
   await expect(page.locator('#start').getByRole('heading', { name: 'Club Live spielt Clubmusik live!' })).toBeVisible()
-  await expect(page.locator('#start iframe[title="Club Live YouTube"]')).toBeVisible()
+
+  await expect(page.locator('video')).toBeVisible()
+  await expect(page.locator('video source')).toHaveAttribute('src', '/videos/irish-pub.mp4')
+
   await expect(
     page.locator('#start').getByText('Wer sich fragt, ob moderne, hoch-produzierte Musik überhaupt')
   ).toBeVisible()

--- a/src/views/home/VideoComponent.vue
+++ b/src/views/home/VideoComponent.vue
@@ -1,12 +1,9 @@
 <template>
   <div class="video">
-    <iframe
-      src="https://www.youtube.com/embed/V5-zxR4yRFo"
-      title="Club Live YouTube"
-      frameborder="0"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-      allowfullscreen
-    ></iframe>
+    <video controls>
+      <source src="/videos/irish-pub.mp4" type="video/mp4">
+      Your browser does not support the video tag.
+    </video>
   </div>
 </template>
 
@@ -28,9 +25,7 @@ export default defineComponent({
   margin-bottom: 1em;
 }
 
-.video iframe,
-.video object,
-.video embed {
+.video video {
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
Please remove sections that don't apply to your change.

## CHANGELOG

### Added
- added mp4 video from irish pub

### Changed
- path for GIT LFS is now `/videos` instead of `/video`

### Removed
- no more iframe from youtube
