### PR TITLE
replace vueuse/head with unhead/vue

### DIFF
--- a/e2e/band.spec.ts
+++ b/e2e/band.spec.ts
@@ -1,0 +1,23 @@
+import test, { expect } from '@playwright/test'
+
+test('should contain the correct title', async ({ page }) => {
+  await page.goto('/band')
+
+  await page.waitForFunction(() => document.title === 'Club Live | Band')
+
+  const title = await page.evaluate(() => document.title)
+  expect(title).toBe('Club Live | Band')
+})
+
+test('should contain the correct meta tags', async ({ page }) => {
+  await page.goto('/band')
+
+  const ogDescription = await page.$eval('meta[property="og:description"]', el => (el as HTMLMetaElement).content)
+  expect(ogDescription).toMatch(/^Aus verschiedenen Regionen Deutschlands/)
+
+  const ogTitle = await page.$eval('meta[property="og:title"]', el => (el as HTMLMetaElement).content)
+  expect(ogTitle).toBe('Club Live | Band')
+
+  const description = await page.$eval('meta[name="description"]', el => (el as HTMLMetaElement).content)
+  expect(description).toMatch(/^Aus verschiedenen Regionen Deutschlands/)
+})

--- a/e2e/shows.spec.ts
+++ b/e2e/shows.spec.ts
@@ -36,3 +36,26 @@ test('references are loaded correctly', async ({ page }) => {
     page.locator('[data-test-id="references"]').getByText('Vaihingen a.d. Enz', { exact: true })
   ).toBeVisible()
 })
+
+
+test('should contain the correct title', async ({ page }) => {
+  await page.goto('/shows')
+
+  await page.waitForFunction(() => document.title === 'Club Live | Shows')
+
+  const title = await page.evaluate(() => document.title)
+  expect(title).toBe('Club Live | Shows')
+})
+
+test('should contain the correct meta tags', async ({ page }) => {
+  await page.goto('/shows')
+
+  const ogDescription = await page.$eval('meta[property="og:description"]', el => (el as HTMLMetaElement).content)
+  expect(ogDescription).toMatch(/^Schaue hier regelmäßig vorbei /)
+
+  const ogTitle = await page.$eval('meta[property="og:title"]', el => (el as HTMLMetaElement).content)
+  expect(ogTitle).toBe('Club Live | Shows')
+
+  const description = await page.$eval('meta[name="description"]', el => (el as HTMLMetaElement).content)
+  expect(description).toMatch(/^Schaue hier regelmäßig vorbei /)
+})

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prettify": "prettier --write src/"
   },
   "dependencies": {
-    "@vueuse/head": "^1.3.1",
+    "@unhead/vue": "^1.7.4",
     "dayjs": "1.11.10",
     "posthog-js": "^1.77.2",
     "vue": "3.3.4",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import { router } from './router'
 import VueCookies from 'vue-cookies'
-import { createHead } from '@vueuse/head'
+import { createHead } from '@unhead/vue'
 import posthog from './plugins/posthog'
 
 const app = createApp(App)

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,46 +518,38 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
-"@unhead/dom@1.3.3", "@unhead/dom@^1.3.1":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@unhead/dom/-/dom-1.3.3.tgz#db16c1266944b1ae1fe3451015d80c78a57422b2"
-  integrity sha512-lagqp2dAAE//WSe5WcCAkI19snMJrLcc0QBWLsFIUXhbKQOR3Y6gr4PeCqwIHGEggEIuAkvaDzJwRd5L/CtqvQ==
+"@unhead/dom@1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@unhead/dom/-/dom-1.7.4.tgz#d6d5899245a0b4e16b01d08553bcde570f8eb00a"
+  integrity sha512-xanQMtGmgikqTvDtuyJy6GXgqvUXOdrdnIyqAabpeS8goD8udxo0stzjtbT8ERbMQibzPGSGcN+Ux+MKoWzrjQ==
   dependencies:
-    "@unhead/schema" "1.3.3"
-    "@unhead/shared" "1.3.3"
+    "@unhead/schema" "1.7.4"
+    "@unhead/shared" "1.7.4"
 
-"@unhead/schema@1.3.3", "@unhead/schema@^1.3.1":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@unhead/schema/-/schema-1.3.3.tgz#dc40b6e92c324bfd9f5524288f70bfb06993b6a3"
-  integrity sha512-5P3Aff/EM5Y4WnJBvvXQqB6CsBq3zdAiK+pf7m0ZXjerc5K5UqKomOtCZ0GXwr10mait7nbca5JaOUiMv2YWjg==
+"@unhead/schema@1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@unhead/schema/-/schema-1.7.4.tgz#c70526f481828c5a4217501a544cfc48a85c1e55"
+  integrity sha512-wUL4CK0NSEm3KH4kYsiqVYQw5xBk1hpBi5tiNj0BTZgpQVrRufICdK5EHA9Fh7OIAR6tOTWwTvsf5+nK0BgQDA==
   dependencies:
     hookable "^5.5.3"
-    zhead "^2.0.10"
+    zhead "^2.1.1"
 
-"@unhead/shared@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@unhead/shared/-/shared-1.3.3.tgz#d7b7365034f7626880183b0baf94eb4e26eeec04"
-  integrity sha512-xcrcKJy/4xE/IFJ4TF43HtGLONfkoedihtV8oR/OKFeeL4DshioZ2X1pmLh7U+Mc+QR3cX027BngWVXaGFOOaw==
+"@unhead/shared@1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@unhead/shared/-/shared-1.7.4.tgz#4ebab1809e96e633b18727c40cc042bf3ab6adcc"
+  integrity sha512-YUNA2UxAuDPnDps41BQ8aEIY5hdyvruSB1Vs3AALhRo07MxMivSq5DjNKfYr/JvRN6593RtfI1NHnP9x5M57xA==
   dependencies:
-    "@unhead/schema" "1.3.3"
+    "@unhead/schema" "1.7.4"
 
-"@unhead/ssr@^1.3.1":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@unhead/ssr/-/ssr-1.3.3.tgz#28e6fbf664e4c5a1741b66c83f6ab6d9d59b1147"
-  integrity sha512-/gSvsWlkgq5aE+kOhvjjYa4TSyXdodsZNST3nqa5+E1rsQswU5o6MJlBVj1mSqnDezQCsmQGeawFfFq8sKgZoQ==
+"@unhead/vue@^1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@unhead/vue/-/vue-1.7.4.tgz#2869e7d8114de9f460d1c4e2ce4db82196eda909"
+  integrity sha512-ZfgzOhg1Bxo9xwp3upawqerw4134hc9Lhz6t005ixcBwPX+39Wpgc9dC3lf+owFQEVuWkf8F+eAwK2sghVBK4A==
   dependencies:
-    "@unhead/schema" "1.3.3"
-    "@unhead/shared" "1.3.3"
-
-"@unhead/vue@^1.3.1":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@unhead/vue/-/vue-1.3.3.tgz#6fb96db92f05ce6d10f1ca019acf35b9e6f2dd83"
-  integrity sha512-arkHRSsexQGLIC255w9zNfPs8gC1P3l4YHB1ZOa1E/30kiEhgq/Z1G3wHaegN0TfM6ODKnTMpxiOQr0mPIiZqQ==
-  dependencies:
-    "@unhead/schema" "1.3.3"
-    "@unhead/shared" "1.3.3"
+    "@unhead/schema" "1.7.4"
+    "@unhead/shared" "1.7.4"
     hookable "^5.5.3"
-    unhead "1.3.3"
+    unhead "1.7.4"
 
 "@vitejs/plugin-vue@4.3.4":
   version "4.3.4"
@@ -778,16 +770,6 @@
   dependencies:
     "@volar/typescript" "~1.10.0"
     "@vue/language-core" "1.8.13"
-
-"@vueuse/head@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@vueuse/head/-/head-1.3.1.tgz#2baa11a8fd4f3f763474792c4ff91c818bf83051"
-  integrity sha512-XCcHGfDzkGlHS7KIPJVYN//L7jpfASLsN7MUE19ndHVQLnPIDxqFLDl7IROsY81PKzawVAUe4OYVWcGixseWxA==
-  dependencies:
-    "@unhead/dom" "^1.3.1"
-    "@unhead/schema" "^1.3.1"
-    "@unhead/ssr" "^1.3.1"
-    "@unhead/vue" "^1.3.1"
 
 abab@^2.0.6:
   version "2.0.6"
@@ -3110,14 +3092,14 @@ ufo@^1.1.2:
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.2.0.tgz#28d127a087a46729133fdc89cb1358508b3f80ba"
   integrity sha512-RsPyTbqORDNDxqAdQPQBpgqhWle1VcTSou/FraClYlHf6TZnQcGslpLcAphNR+sQW4q5lLWLbOsRlh9j24baQg==
 
-unhead@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/unhead/-/unhead-1.3.3.tgz#3c9b9353ee4bb52971581d3c90f2eae21e738d7e"
-  integrity sha512-4lGYtrwqsvlw1Grkvyz9vV5H/1ttU/ApqXQwAPpQ4WX/S54QHZNNVD/DjqYR+7QEGkWHxyQgxYoqaeeE0pUlRw==
+unhead@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/unhead/-/unhead-1.7.4.tgz#acf3e01b2a035ba6101cb34e41a72277025284b0"
+  integrity sha512-oOv+9aQS85DQUd0f1uJBtb2uG3SKwCURSTuUWp9WKKzANCb1TjW2dWp5TFmJH5ILF6urXi4uUQfjK+SawzBJAA==
   dependencies:
-    "@unhead/dom" "1.3.3"
-    "@unhead/schema" "1.3.3"
-    "@unhead/shared" "1.3.3"
+    "@unhead/dom" "1.7.4"
+    "@unhead/schema" "1.7.4"
+    "@unhead/shared" "1.7.4"
     hookable "^5.5.3"
 
 universalify@^0.1.0:
@@ -3416,7 +3398,7 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-zhead@^2.0.10:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/zhead/-/zhead-2.0.10.tgz#dc89c420081fae78a6f3d10687428ae676bc6291"
-  integrity sha512-irug8fXNKjqazkA27cFQs7C6/ZD3qNiEzLC56kDyzQART/Z9GMGfg8h2i6fb9c8ZWnIx/QgOgFJxK3A/CYHG0g==
+zhead@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/zhead/-/zhead-2.1.1.tgz#42950fbd5468268a07dc5b042a6c0261d340535d"
+  integrity sha512-FRmjAFioi07R+bmL+fqbkXF/pCbC9PwcKQ8RDluC5xTaVbNBgYRQ4eKuS1C8c7Sil//UIxet/AGp7D6royoHhA==


### PR DESCRIPTION
According to the changelog of vueuse/head, they will discontinue `@vueue/head`.
https://github.com/julisch94/clublive-website/pull/298

They proposed to switch to `@unhead/vue` which is done with this PR.

## CHANGELOG

### Changed
- replaced `@vueuse/head` with `@unhead/vue`
