### PR TITLE
fix and re-activate e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ Make sure to set `headless: true` in `playwright.config.ts` and run the followin
 
 ```bash
 # Run each test 5 times
-npx playwright test --repeat-each 5
+yarn playwright test --repeat-each 5
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ We are using prettier for auto-formatting. Make sure you have a prettier plugin 
 Please also make sure that it's using the `.prettierrc` config file provided in this project.
 
 To confirm your configuration run the following command. It should not make any changes to your code base:
+
 ```
 yarn prettify
 ```
@@ -37,3 +38,16 @@ We are using Netlify to deploy the page. Pushes to the main branch automatically
 Opening a PR will also trigger a deployment, though to a dedicated ephemeral environment. Netlify has GitHub hooks
 in-place that will post a URL to your PR deployment as part of the GitHub checks. You should be able to simply click
 on that link and check out your changes live.
+
+## Troubleshooting
+
+### Flaky E2E Tests
+
+In case you ever run into flaky e2e tests, you can try to run them locally in **headless** mode and **repeat each** test multiple times. To narrow down the issue, you can run a **single test case** using `test.only()`.
+
+Make sure to set `headless: true` in `playwright.config.ts` and run the following command:
+
+```bash
+# Run each test 5 times
+npx playwright test --repeat-each 5
+```

--- a/e2e/band.spec.ts
+++ b/e2e/band.spec.ts
@@ -1,4 +1,5 @@
 import test, { expect } from '@playwright/test'
+import { waitForHead } from './wait-for-head'
 
 test('should contain the correct title', async ({ page }) => {
   await page.goto('/band')
@@ -9,11 +10,10 @@ test('should contain the correct title', async ({ page }) => {
   expect(title).toBe('Club Live | Band')
 })
 
-// flaky
-test.skip('should contain the correct meta tags', async ({ page }) => {
+test('should contain the correct meta tags', async ({ page }) => {
   await page.goto('/band')
 
-  await page.waitForLoadState()
+  await waitForHead()
 
   const ogDescription = await page.$eval('meta[property="og:description"]', el => (el as HTMLMetaElement).content)
   expect(ogDescription).toMatch(/^Aus verschiedenen Regionen Deutschlands/)

--- a/e2e/shows.spec.ts
+++ b/e2e/shows.spec.ts
@@ -46,18 +46,17 @@ test('should contain the correct title', async ({ page }) => {
   expect(title).toBe('Club Live | Shows')
 })
 
-// flaky
-test.skip('should contain the correct meta tags', async ({ page }) => {
+test('should contain the correct meta tags', async ({ page }) => {
   await page.goto('/shows')
 
   await page.waitForLoadState()
 
-  const ogDescription = await page.$eval('meta[property="og:description"]', el => (el as HTMLMetaElement).content)
+  const ogDescription = await page.locator('meta[property="og:description"]').getAttribute('content')
   expect(ogDescription).toMatch(/^Schaue hier regelmäßig vorbei /)
 
-  const ogTitle = await page.$eval('meta[property="og:title"]', el => (el as HTMLMetaElement).content)
+  const ogTitle = await page.locator('meta[property="og:title"]').getAttribute('content')
   expect(ogTitle).toBe('Club Live | Shows')
 
-  const description = await page.$eval('meta[name="description"]', el => (el as HTMLMetaElement).content)
+  const description = await page.locator('meta[name="description"]').getAttribute('content')
   expect(description).toMatch(/^Schaue hier regelmäßig vorbei /)
 })

--- a/e2e/shows.spec.ts
+++ b/e2e/shows.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { waitForHead } from './wait-for-head'
 
 test('open up menu and go to shows', async ({ page }) => {
   await page.goto('/')
@@ -49,7 +50,7 @@ test('should contain the correct title', async ({ page }) => {
 test('should contain the correct meta tags', async ({ page }) => {
   await page.goto('/shows')
 
-  await page.waitForLoadState()
+  await waitForHead()
 
   const ogDescription = await page.locator('meta[property="og:description"]').getAttribute('content')
   expect(ogDescription).toMatch(/^Schaue hier regelmäßig vorbei /)

--- a/e2e/wait-for-head.ts
+++ b/e2e/wait-for-head.ts
@@ -1,0 +1,7 @@
+// There is a delay in the unhead/vue library that
+// causes the head section to update a bit later, causing flaky tests.
+// This is a workaround to wait for the head to be updated before continuing.
+// see: https://github.com/unjs/unhead/discussions/144
+export const waitForHead = async () => {
+  await new Promise(resolve => setTimeout(resolve, 200))
+}


### PR DESCRIPTION
## CHANGELOG

### Added
- added a note to the `README.md`
- added a timeout in tests for the meta tags to wait for the DOM to update, see: https://github.com/unjs/unhead/discussions/144

### Changed
- dropped `skip` tag from flaky tests; they are activated again
