### PR TITLE
make video prop optional; gets rid of warning

### DIFF
--- a/src/components/VideoComponent.vue
+++ b/src/components/VideoComponent.vue
@@ -5,7 +5,7 @@ withDefaults(
   defineProps<{
     poster?: string
     src: string
-    mode: 'portrait' | 'landscape'
+    mode?: 'portrait' | 'landscape'
   }>(),
   {
     mode: 'portrait',


### PR DESCRIPTION
## CHANGELOG

### Fixed
- get rid of warning in the console
