### PR TITLE
reorder content on /band and /shows

### DIFF
--- a/e2e/shows.spec.ts
+++ b/e2e/shows.spec.ts
@@ -16,7 +16,6 @@ test('shows page is loaded correctly', async ({ page }) => {
   ).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Referenzen' })).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Buchungsanfrage' })).toBeVisible()
-  await expect(page.getByText('Stay tuned und folge uns bei Instagram')).toBeVisible()
 })
 
 test('references are loaded correctly', async ({ page }) => {

--- a/src/views/band/Band.vue
+++ b/src/views/band/Band.vue
@@ -6,6 +6,27 @@
           <h1>Band</h1>
         </header>
         <p class="justify-on-desktop">
+          Club Live spielt mit einer siebenköpfigen Live-Besetzung. Schlagzeug, E-Bass, E-Gitarre, Keyboards, Saxophon
+          und Trompete. Immer dabei sind unsere Frontfrau Tiffany und unser Frontmann Jules, der auch die E-Gitarre
+          spielt. Über die Jahre sind wir mit immer mehr Musikern zu einer großen Club Live Family herangewachsen. Hier
+          stellen wir euch ein paar Mitglieder unserer Club Live Family vor.
+        </p>
+        <div class="grid">
+          <Musician
+            v-for="musician in musicians"
+            :key="musician.name"
+            :image-src="musician.imageSrc"
+            :name="musician.name"
+            :instrument="musician.instrument"
+          />
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="inner pa">
+        <h2>Unsere Vision</h2>
+        <p class="justify-on-desktop">
           Als unsere Band im Jahr 2017 gegründet wurde, spielten wir Songs, die wir aus dem Radio und aus den Clubs
           kannten – mit einer handvoll Leuten in einem kleinen Proberaum in Karlsruhe-Rheinhafen. Aber wir waren uns
           schnell einig, wohin unsere musikalische Reise gehen sollte. Denn wir merkten, dass viele unserer Freunde in
@@ -35,27 +56,6 @@
           Spielst auch du ein Instrument und hast Interesse bei uns einzusteigen? Dann schreibe uns gerne eine E-Mail an
           <a href="mailto:contact@clublive.band">contact@clublive.band</a>.
         </p>
-      </div>
-    </section>
-
-    <section>
-      <div class="inner pa">
-        <h2>Besetzung</h2>
-        <p class="justify-on-desktop">
-          Club Live spielt mit einer siebenköpfigen Live-Besetzung. Schlagzeug, E-Bass, E-Gitarre, Keyboards, Saxophon
-          und Trompete. Immer dabei sind unsere Frontfrau Tiffany und unser Frontmann Jules, der auch die E-Gitarre
-          spielt. Über die Jahre sind wir mit immer mehr Musikern zu einer großen Club Live Family herangewachsen. Hier
-          stellen wir euch ein paar Mitglieder unserer Club Live Family vor.
-        </p>
-        <div class="grid">
-          <Musician
-            v-for="musician in musicians"
-            :key="musician.name"
-            :image-src="musician.imageSrc"
-            :name="musician.name"
-            :instrument="musician.instrument"
-          />
-        </div>
       </div>
     </section>
 

--- a/src/views/shows/Shows.vue
+++ b/src/views/shows/Shows.vue
@@ -5,6 +5,7 @@
         <header class="major">
           <h1>Shows</h1>
         </header>
+        <ShowList />
         <p>
           Never miss a beat! Schau hier regelmäßig rein, um zu sehen, wann wir wieder in deine Nähe kommen. Komm rum und
           feier mit uns zusammen Clubmusik! Festivals, Stadtfeste, Vereins-Events, private Feiern und vieles mehr. Um
@@ -16,19 +17,6 @@
           Weihnachtsfeier, Geburtstagsfeier, Abschlussfeier, Gartenparty – für den Live-Party-Boost bist du hier genau
           richtig. Schreib uns eine unverbindliche Anfrage über unser <a href="#contact">Kontaktformular</a> und lass
           uns deine Party zum Beben bringen!
-        </p>
-      </div>
-    </section>
-
-    <section>
-      <div class="inner pa">
-        <h2>Anstehende Shows</h2>
-
-        <ShowList />
-
-        <p style="padding-top: 2em">
-          Stay tuned und folge uns bei Instagram:
-          <a href="https://instagram.com/clublive.band">instagram.com/clublive.band</a>
         </p>
       </div>
     </section>


### PR DESCRIPTION
## CHANGELOG

### Screenshots

| description | before | after |
|------| ---- | ----- |
|   moved more interesting stuff further up   |  <img width="1728" alt="image" src="https://github.com/julisch94/clublive-website/assets/22644876/2fa83caa-9089-4ac9-b3bb-193f479252db">  | <img width="1728" alt="image" src="https://github.com/julisch94/clublive-website/assets/22644876/3d162f5d-d474-4f00-8a09-78b093a1488c">  |

### Added

### Changed
- changed the order of the elements on the /band page
  - now, the band pictures come first, then the history and the vision of the band
- changed the order of the elements on the /shows page
  - now, the upcoming shows come first, then the text

